### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ test:
 .PHONY: clean
 clean:
 	go clean
-	rm -f policy.wasm annotated-policy.wasm artifacthub-pkg.yml
+rm -f policy.wasm annotated-policy.wasm
 
 .PHONY: e2e-tests
 e2e-tests: annotated-policy.wasm

--- a/metadata.yml
+++ b/metadata.yml
@@ -22,6 +22,7 @@ annotations:
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/tests/go-wasi-context-aware-test-policy
   # kubewarden specific:
   io.kubewarden.policy.title: go-wasi-context-aware-test-policy
+  io.kubewarden.policy.version: 
   io.kubewarden.policy.description: A test policy that uses context-aware capabilities
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/go-wasi-context-aware-test-policy


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
Co-authored-by: Flavio Castelli <fcastelli@suse.com>
