### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ name: Release policy
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       artifacthub: false
 
@@ -24,7 +24,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go-wasi.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go-wasi.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/tests/go-wasi-context-aware-test-policy
       artifacthub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,6 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
-    with:
-      artifacthub: false
 
   release:
     needs: test
@@ -27,4 +25,3 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-go-wasi.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       oci-target: ghcr.io/${{ github.repository_owner }}/tests/go-wasi-context-aware-test-policy
-      artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,5 +4,3 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
-    with:
-      artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,6 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-go-wasi.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
     with:
       artifacthub: false

--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,6 @@ policy.wasm: $(SOURCE_FILES) go.mod go.sum
 	GOOS=wasip1 GOARCH=wasm go build -gcflags=all="-B" -ldflags="-w -s" -o policy.wasm
 	wasm-opt --enable-bulk-memory -Oz -o policy.wasm policy.wasm 
 
-artifacthub-pkg.yml: metadata.yml go.mod
-	$(warning If you are updating the artifacthub-pkg.yml file for a release, \
-	  remember to set the VERSION variable with the proper value. \
-	  To use the latest tag, use the following command:  \
-	  make VERSION=$$(git describe --tags --abbrev=0 | cut -c2-) annotated-policy.wasm)
-	kwctl scaffold artifacthub \
-	  --metadata-path metadata.yml --version $(VERSION) \
-	  --output artifacthub-pkg.yml
 
 annotated-policy.wasm: policy.wasm metadata.yml
 	kwctl annotate -m metadata.yml -u README.md -o annotated-policy.wasm policy.wasm
@@ -42,7 +34,7 @@ test:
 .PHONY: clean
 clean:
 	go clean
-	rm -f policy.wasm annotated-policy.wasm artifacthub-pkg.yml
+	rm -f policy.wasm annotated-policy.wasm
 
 .PHONY: e2e-tests
 e2e-tests: annotated-policy.wasm

--- a/metadata.yml
+++ b/metadata.yml
@@ -22,7 +22,7 @@ annotations:
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/tests/go-wasi-context-aware-test-policy
   # kubewarden specific:
   io.kubewarden.policy.title: go-wasi-context-aware-test-policy
-  io.kubewarden.policy.version: 
+  io.kubewarden.policy.version: 0.0.1-unreleased
   io.kubewarden.policy.description: A test policy that uses context-aware capabilities
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/go-wasi-context-aware-test-policy

--- a/metadata.yml
+++ b/metadata.yml
@@ -22,6 +22,7 @@ annotations:
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/tests/go-wasi-context-aware-test-policy
   # kubewarden specific:
   io.kubewarden.policy.title: go-wasi-context-aware-test-policy
+  io.kubewarden.policy.version: 
   io.kubewarden.policy.description: A test policy that uses context-aware capabilities
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/go-wasi-context-aware-test-policy


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
Co-authored-by: Flavio Castelli <fcastelli@suse.com>
